### PR TITLE
Changing the Ruby dependency to include Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         ruby:
           - '3.4'
           - '3.1'
+          - '3.0' # added for Inspec compatibility
 
     runs-on: ubuntu-latest
 

--- a/chef-gyoku.gemspec
+++ b/chef-gyoku.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/savonrb/#{s.name}"
   s.summary = "Translates Ruby Hashes to XML"
   s.description = "Gyoku translates Ruby Hashes to XML"
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = ">= 3.0" # setting the Ruby version requirement to 3.0 or higher to be backwards compatible with Inspec v 5.0.0
 
   s.license = "MIT"
 
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "standard"
   s.add_development_dependency "fiddle"
-  s.add_development_dependency "cookstyle", ">= 8.0.0"
+  s.add_development_dependency "cookstyle", "~> 8.0"
 
   s.files = `git ls-files`.split("\n")
 

--- a/chef-gyoku.gemspec
+++ b/chef-gyoku.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/savonrb/#{s.name}"
   s.summary = "Translates Ruby Hashes to XML"
   s.description = "Gyoku translates Ruby Hashes to XML"
-  s.required_ruby_version = ">= 3.0" # setting the Ruby version requirement to 3.0 or higher to be backwards compatible with Inspec v 5.0.0
+  s.required_ruby_version = ">= 3.0" # setting the Ruby version requirement to 3.0 or higher to be backwards compatible with Inspec v 5.0.0 and AIX
 
   s.license = "MIT"
 

--- a/lib/chef-gyoku/version.rb
+++ b/lib/chef-gyoku/version.rb
@@ -1,3 +1,3 @@
 module Gyoku
-  VERSION = "1.5.0".freeze
+  VERSION = "1.5.1".freeze
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Inspec 5 uses this gem but requires Ruby 3.0 compatibility. Here we are updating our requirement to cover that.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
